### PR TITLE
Choose setup destination & Fix "pyinstaller" command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ place `version.py` and `persepolis.ico` in perseplois folder.
 run Windows cmd or powershell (as Admin) and enter persepolis folder so build persepolis by pyinstaller with this command:
 
 ```
-pyinstaller '.\persepolis\Persepolis Download Manager.py'  -p "C:\Program Files (x86)\Windows Kits\10
-\Redist\ucrt\DLLs\x64" -p C:\python35\Lib\site-packages\PyQt5\Qt\bin\ -w -F -i persepolis.ico -n "Persepolis Download Manager
-" --version-file version.py
+pyinstaller ".\persepolis\Persepolis Download Manager.py" -p "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64" -p C:\python35\Lib\site-packages\PyQt5\Qt\bin\ -w -F -i persepolis.ico -n "Persepolis Download Manager" --version-file version.py
 ```
 
 If you changed **windows SDK** (step 1-4) and **python** (step 1-2) installation directory you should change `-p(path)`

--- a/setupX32.iss
+++ b/setupX32.iss
@@ -19,7 +19,7 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={commonpf}\{#MyAppName}
-DisableDirPage=yes
+DisableDirPage=auto
 DisableProgramGroupPage=yes
 ; The [Icons] "quicklaunchicon" entry uses {userappdata} but its [Tasks] entry has a proper IsAdminInstallMode Check.
 UsedUserAreasWarning=no

--- a/setupX64.iss
+++ b/setupX64.iss
@@ -19,7 +19,7 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={commonpf}\{#MyAppName}
-DisableDirPage=yes
+DisableDirPage=auto
 DisableProgramGroupPage=yes
 ; The [Icons] "quicklaunchicon" entry uses {userappdata} but its [Tasks] entry has a proper IsAdminInstallMode Check.
 UsedUserAreasWarning=no


### PR DESCRIPTION
In this Pull Request:

1. Change "DisableDirPage" to "auto" instead of "yes" in the files: SetupX32.iss & SetupX64.iss, in order to let the user choose where to install the app at 1st time installation.

2. Update README.md to make the "pyinstaller" command readable by cmd.exe, by wrapping strings in the command with double quotes instead of single quotes, and change line feeds to spaces so that the command can be copied and pasted into command prompt as a single command.